### PR TITLE
Remove prometheus collector middleware

### DIFF
--- a/api/config.ru
+++ b/api/config.ru
@@ -2,9 +2,9 @@
 
 require './minitwit_sim_api'
 
-require 'prometheus/middleware/collector'
+#require 'prometheus/middleware/collector'
 require 'prometheus/middleware/exporter'
-use Prometheus::Middleware::Collector
+#use Prometheus::Middleware::Collector #collects wayyyy too much stuff
 use Prometheus::Middleware::Exporter
 
 run MiniTwit::SimAPI.freeze.app

--- a/api/config.ru
+++ b/api/config.ru
@@ -2,9 +2,9 @@
 
 require './minitwit_sim_api'
 
-#require 'prometheus/middleware/collector'
+# require 'prometheus/middleware/collector'
 require 'prometheus/middleware/exporter'
-#use Prometheus::Middleware::Collector #collects wayyyy too much stuff
+# use Prometheus::Middleware::Collector # left for debugging purposes
 use Prometheus::Middleware::Exporter
 
 run MiniTwit::SimAPI.freeze.app

--- a/app/config.ru
+++ b/app/config.ru
@@ -5,9 +5,9 @@ Dotenv.load
 
 require './config/app_environment'
 require './minitwit'
-require 'prometheus/middleware/collector'
+#require 'prometheus/middleware/collector'
 require 'prometheus/middleware/exporter'
-use Prometheus::Middleware::Collector
+#use Prometheus::Middleware::Collector
 use Prometheus::Middleware::Exporter
 
 run MiniTwit::App.freeze.app

--- a/app/config.ru
+++ b/app/config.ru
@@ -5,9 +5,9 @@ Dotenv.load
 
 require './config/app_environment'
 require './minitwit'
-#require 'prometheus/middleware/collector'
+# require 'prometheus/middleware/collector'
 require 'prometheus/middleware/exporter'
-#use Prometheus::Middleware::Collector
+# use Prometheus::Middleware::Collector # left for debugging purposes
 use Prometheus::Middleware::Exporter
 
 run MiniTwit::App.freeze.app


### PR DESCRIPTION
The prometheus collector middleware creates a counter for each unique url request made to the server. Since our server uses usernames in URLs, it will create a new counter for each user in the system. Removing the middleware will stop prometheus from tracking this. The middleware collects info that we are currently not using, so no loss here. 